### PR TITLE
Made it so that the plugin can take server downtime into account

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -60,7 +60,10 @@ life-settings:
     ##THEY ONLY CAN GAIN THEM FROM THE COMMAND. Does not reset on resets.
     enabled: false
     max-extra-lives: 2
-
+  count-offline-time: true
+    #Makes it so that the respawn timer keeps running when the server is offline
+    #(or, rather, that it calculates how much time has passed since it went offline on startup)
+    #Currently only implemented for all-death mode
 
 
 


### PR DESCRIPTION
Essentially, what this means is that whenever the server starts, the plugin checks how much time (in unix epoch seconds) has passed since it last went offline, in ticks, and checks whether player's death timers have elapsed or not. Currently only implemented for the all-death mode. 